### PR TITLE
cinder list fails with 'name' sort key

### DIFF
--- a/cinder/api/v2/volumes.py
+++ b/cinder/api/v2/volumes.py
@@ -224,6 +224,9 @@ class VolumeController(wsgi.Controller):
                                             self._get_volume_filter_options())
 
         # NOTE(thingee): v2 API allows name instead of display_name
+        if 'name' == sort_key:
+            sort_key = 'display_name'
+
         if 'name' in filters:
             filters['display_name'] = filters['name']
             del filters['name']

--- a/cinder/tests/api/v2/test_volumes.py
+++ b/cinder/tests/api/v2/test_volumes.py
@@ -20,6 +20,7 @@ from lxml import etree
 from oslo.config import cfg
 import six.moves.urllib.parse as urlparse
 import webob
+import mock
 
 from cinder.api import extensions
 from cinder.api.v2 import volumes
@@ -1387,6 +1388,21 @@ class VolumeApiTest(test.TestCase):
                          {'key': 'value',
                           'attached_mode': 'visible',
                           'readonly': 'visible'})
+
+    @mock.patch('cinder.volume.api.API.get_all')
+    def test_get_volumes_sort_by_name(self, get_all):
+        """Name in client means display_name in database."""
+
+        req = mock.MagicMock()
+        ctxt = context.RequestContext('fake', 'fake', auth_token=True)
+        req.environ = {'cinder.context': ctxt}
+        req.params = {'sort_key': 'name'}
+        self.controller._view_builder.detail_list = mock.Mock()
+        self.controller._get_volumes(req, True)
+        get_all.assert_called_once_with(
+            ctxt, None, None,
+            'display_name', 'desc',
+            {}, viewable_admin_meta=True)
 
 
 class VolumeSerializerTest(test.TestCase):


### PR DESCRIPTION
Change sort key from `name` to `display_name` if the key, `name` exists.

Change-Id: I9e285c7de2e860b251f881ab82d8d2d93e1191d2
Closes-Bug: #1404020
(cherry picked from commit 3b77f765c065c5f29aef5af2febe086691affebc)