### PR TITLE
only allow force create snapshot when volume is usable.

### DIFF
--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -552,8 +552,14 @@ class API(base.Base):
             msg = _("Snapshot of secondary replica is not allowed.")
             raise exception.InvalidVolume(reason=msg)
 
-        if ((not force) and (volume['status'] != "available")):
-            msg = _("must be available")
+        if volume['status'] not in ['available', 'in-use']:
+            msg = (_('Volume must be available or in-use, '
+                     'but the current status is "%s".')
+                   % volume['status'])
+            raise exception.InvalidVolume(reason=msg)
+        elif ((not force) and (volume['status'] == "in-use")):
+            msg = _('Creating a snapshot on in-use volume '
+                    'must use the force flag.')
             raise exception.InvalidVolume(reason=msg)
 
         try:


### PR DESCRIPTION
Volume deleting may take a while, but create_snapshot_force
ignors volume status. So if a snapshot is created while the
volume is deleting, when the deletion is finished, this newly
created snapshot will be left totally unusable. To resolve
this, just allow force create snapshot if volume status is
'available' or 'in-use' just like force backup.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>