### PR TITLE
Rbd driver support reverting to any snapshot

### DIFF
--- a/cinder/volume/drivers/rbd.py
+++ b/cinder/volume/drivers/rbd.py
@@ -249,7 +249,7 @@ class RBDDriver(driver.VolumeDriver):
     """Implements RADOS block device (RBD) volume commands."""
 
     VERSION = '1.1.0'
-    support_reverting_to_any_snapshot = False
+    support_reverting_to_any_snapshot = True
 
     def __init__(self, *args, **kwargs):
         super(RBDDriver, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The commit 878eb1cff372cd630cc45630b3f514423f4fb3bc not allow rbd
reverting to any snapshot, just enable support_revert_to_any_snapshot
flag.

Signed-off-by: Xiaojun Liao <xiaojunliao85@gmail.com>